### PR TITLE
Force unicode on address for python 2.X compat

### DIFF
--- a/zbeacon.py
+++ b/zbeacon.py
@@ -146,7 +146,7 @@ class ZBeaconAgent(object):
     
     def _init_socket(self):
         try:
-            if ipaddress.IPv4Address(self.announce_addr).is_multicast:
+            if ipaddress.IPv4Address(unicode(self.announce_addr)).is_multicast:
                 # TTL
                 self._udp_sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
                 # TODO: This should only be used if we do not have inproc method! 


### PR DESCRIPTION
Python 2.X doesnt include the `ipaddress` module a [port can be used from pypi](https://pypi.python.org/pypi/ipaddress) and the port needs the address string to be unicode as they say on the [Readme](https://github.com/phihag/ipaddress)
