### PR TITLE
Fix ip address format for python2.7

### DIFF
--- a/zbeacon.py
+++ b/zbeacon.py
@@ -149,7 +149,10 @@ class ZBeaconAgent(object):
             # ipv4 only currently and needs a valid broadcast address
             for name, data in iface.items():
                 if data.get(2) and data[2].get('broadcast'):
-                    ipadr = ipaddress.IPv4Address(data[2].get('addr'))
+                    addr = data[2].get('addr')
+                    if (sys.version_info.major < 3):
+                        addr = addr.decode('utf-8')
+                    ipadr = ipaddress.IPv4Address(addr)
                     if not ipadr.is_loopback:
                         netmask = data[2].get('netmask')
                         ifc = ipaddress.ip_interface("%s/%s" %(ipadr, netmask))


### PR DESCRIPTION
Trying to run the current version on python2.7 results in the following error:

``` python
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib64/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/lib64/python2.7/site-packages/pyre/zbeacon.py", line 152, in __init__
    ipadr = ipaddress.IPv4Address(data[2].get('addr'))
  File "/usr/lib64/python2.7/site-packages/ipaddress.py", line 1269, in __init__
    self._check_packed_address(address, 4)
  File "/usr/lib64/python2.7/site-packages/ipaddress.py", line 526, in _check_packed_address
    expected_len, self._version))
AddressValueError: '10.0.2.15' (len 9 != 4) is not permitted as an IPv4 address (did you pass in a bytes instead of a unicode object?)
```

This patch is one possible fix for that bug.
