### PR TITLE
Measure and Improve Test Coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+# Configuration for coverage.py
+
+[run]
+branch = True
+source = pyre
+include = */pyre/*
+omit =
+    */setup.py
+
+[report]
+exclude_lines =
+    def __repr__
+    if __name__ == .__main__.:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ python:
   - "3.4"
 
 install:
-  - pip install nose
+  - pip install nose coveralls
   - pip install .
 
 script: 
-    - pwd
-    - nosetests -v --exe
+    - nosetests -v --exe --with-cov --cover-package pyre
+
+after_success:
+    - coveralls

--- a/pyre/zbeacon.py
+++ b/pyre/zbeacon.py
@@ -292,7 +292,7 @@ class ZBeacon(object):
                 break
 
 
-if __name__ == '__main__':  # pragma: no cover
+if __name__ == '__main__':
     import zmq
     import struct
     import time

--- a/pyre/zbeacon.py
+++ b/pyre/zbeacon.py
@@ -292,7 +292,7 @@ class ZBeacon(object):
                 break
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: no cover
     import zmq
     import struct
     import time

--- a/pyre/zre_msg.py
+++ b/pyre/zre_msg.py
@@ -459,9 +459,11 @@ class ZreMsg(object):
             self._put_long_string(val)
 
 if __name__ == '__main__':
+    pass
+
+"""
     logger.addHandler(logging.StreamHandler())
     logger.setLevel(logging.DEBUG)
-    self._put_long_string("%s=%s" % (key, val))
 
     testdata = struct.pack('>Hb9sII2sI2sI2sbb4sIb1sI1sb1sI1s',
                            11,         # sequence
@@ -492,3 +494,4 @@ if __name__ == '__main__':
 
     logger.debug("Unpack the packed HELLO message")
     m.unpack_hello()
+"""

--- a/tests/test_pyre.py
+++ b/tests/test_pyre.py
@@ -182,7 +182,6 @@ class PyreTest(unittest.TestCase):
     # end test_zfinal
 # end PyreTest
 
-
 if __name__ == '__main__':
     inst_count = 0
 

--- a/tests/test_zbeacon.py
+++ b/tests/test_zbeacon.py
@@ -55,14 +55,6 @@ class ZBeaconTest(unittest.TestCase):
         self.node2.send(self.transmit2)
         req = self.node1.recv_multipart()
         self.assertEqual(self.transmit2, req[1])
-    
-    def test_recv_beacon1(self):
-        self.node1.send_unicode("PUBLISH", zmq.SNDMORE)
-        self.node1.send(self.transmit1)
-        self.node2.send_unicode("PUBLISH", zmq.SNDMORE)
-        self.node2.send(self.transmit2)
-        req = self.node2.recv_multipart()
-        self.assertEqual(self.transmit1, req[1])
 
 # end ZBeaconTest
 

--- a/tests/test_zbeacon.py
+++ b/tests/test_zbeacon.py
@@ -53,8 +53,8 @@ class ZBeaconTest(unittest.TestCase):
         self.node1.send(self.transmit1)
         self.node2.send_unicode("PUBLISH", zmq.SNDMORE)
         self.node2.send(self.transmit2)
-        req = self.node1.recv_multipart()
-        self.assertEqual(self.transmit2, req[1])
+        req = self.node2.recv_multipart()
+        self.assertEqual(self.transmit1, req[1])
 
 # end ZBeaconTest
 

--- a/tests/test_zhelper.py
+++ b/tests/test_zhelper.py
@@ -34,7 +34,6 @@ class ZHelperTest(unittest.TestCase):
         pipe = zhelper.zthread_fork(zmq.Context(), task)
         pipe.send(b'hello')
         assert pipe.recv() == b'goodbye'
-        pipe.close()
 
 # end ZHelperTest
 

--- a/tests/test_zhelper.py
+++ b/tests/test_zhelper.py
@@ -34,6 +34,7 @@ class ZHelperTest(unittest.TestCase):
         pipe = zhelper.zthread_fork(zmq.Context(), task)
         pipe.send(b'hello')
         assert pipe.recv() == b'goodbye'
+        pipe.close()
 
 # end ZHelperTest
 

--- a/tests/test_zhelper.py
+++ b/tests/test_zhelper.py
@@ -25,6 +25,16 @@ class ZHelperTest(unittest.TestCase):
         self.assertIn('127.0.0.1', addrs)
     # end test_get_ifaddrs_loopback
 
+    def test_zthread_fork(self):
+
+        def task(ctx, pipe):
+            pipe.recv()
+            pipe.send(b'goodbye')
+
+        pipe = zhelper.zthread_fork(zmq.Context(), task)
+        pipe.send(b'hello')
+        assert pipe.recv() == b'goodbye'
+
 # end ZHelperTest
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds coveralls support for Pyre, and improves coverage by 5%.

Before:

```
---------- coverage: platform darwin, python 3.4.3-final-0 -----------
Name                 Stmts   Miss  Cover
----------------------------------------
pyre/__init__            2      0   100%
pyre/pyre              149     53    64%
pyre/pyre_group         23      4    83%
pyre/pyre_node         337     43    87%
pyre/pyre_peer         101     14    86%
pyre/zactor             76     14    82%
pyre/zbeacon           187     44    76%
pyre/zhelper           250    130    48%
pyre/zre_msg           281     65    77%
pyre/zsocket            16      1    94%
setup                    5      5     0%
tests/test_pyre        110      7    94%
tests/test_zactor       27     10    63%
tests/test_zbeacon      59     16    73%
tests/test_zhelper      20      1    95%
----------------------------------------
TOTAL                 1643    407    75%
----------------------------------------------------------------------
Ran 16 tests in 11.301s
```

After:

```
---------- coverage: platform darwin, python 3.4.3-final-0 -----------
Name                 Stmts   Miss Branch BrMiss  Cover
------------------------------------------------------
pyre/__init__            2      0      0      0   100%
pyre/pyre              110     10      8      4    88%
pyre/pyre_group         18      0      4      0   100%
pyre/pyre_node         337     39    130     32    85%
pyre/pyre_peer         101     14     12      6    82%
pyre/zactor             74     13      8      2    82%
pyre/zbeacon           174     32     70     18    80%
pyre/zhelper           250    111     78     38    55%
pyre/zre_msg           269     53     72     26    77%
pyre/zsocket            16      1      4      1    90%
tests/test_pyre        141      0      2      1    99%
tests/test_zactor       16      0      0      0   100%
tests/test_zbeacon      41      0      0      0   100%
tests/test_zhelper      25      0      6      0   100%
------------------------------------------------------
TOTAL                 1574    273    394    128    80%
----------------------------------------------------------------------
Ran 21 tests in 15.352s
```
