### PR TITLE
Fix STOP message

### DIFF
--- a/pyre/pyre_node.py
+++ b/pyre/pyre_node.py
@@ -126,7 +126,7 @@ class PyreNode(object):
             # Stop polling on inbox
             self.poller.unregister(self.inbox)
         self.outbox.send_unicode("STOP", zmq.SNDMORE)
-        self.outbox.send_unicode(self.identity.bytes, zmq.SNDMORE)
+        self.outbox.send(self.identity.bytes, zmq.SNDMORE)
         self.outbox.send_unicode(self.name)
 
     def bind(self, endpoint):

--- a/pyre/pyre_node.py
+++ b/pyre/pyre_node.py
@@ -126,7 +126,7 @@ class PyreNode(object):
             # Stop polling on inbox
             self.poller.unregister(self.inbox)
         self.outbox.send_unicode("STOP", zmq.SNDMORE)
-        self.outbox.send_unicode(self.identity.hex, zmq.SNDMORE)
+        self.outbox.send_unicode(self.identity.bytes, zmq.SNDMORE)
         self.outbox.send_unicode(self.name)
 
     def bind(self, endpoint):


### PR DESCRIPTION
The STOP message should send the node id as a string of 16 bytes instead of a hex string.

Fixes https://github.com/z25/pyZOCP/issues/57