### PR TITLE
Major Pyre API change to equal Zyre api

### DIFF
--- a/examples/chat.py
+++ b/examples/chat.py
@@ -6,7 +6,7 @@ import logging
 import sys
 
 def chat_task(ctx, pipe):
-    n = Pyre(ctx)
+    n = Pyre(ctx=ctx)
     n.join("CHAT")
     n.start()
 

--- a/examples/high_volume.py
+++ b/examples/high_volume.py
@@ -8,7 +8,7 @@ from pyre import zhelper
 
 
 def chat_task(ctx, pipe, ncmds):
-    n = Pyre(ctx)
+    n = Pyre(ctx=ctx)
     n.join("CHAT")
     n.start()
 

--- a/pyre/pyre.py
+++ b/pyre/pyre.py
@@ -30,7 +30,8 @@ class Pyre(object):
         Kwargs:
             ctx: PyZMQ Context, if not specified a new context will be created
         """
-        if kwargs.get('ctx') == None:
+        ctx = kwargs.get('ctx')
+        if ctx == None:
             ctx = zmq.Context()
         self._ctx = ctx
         self._uuid = None

--- a/pyre/pyre.py
+++ b/pyre/pyre.py
@@ -18,16 +18,24 @@ logger = logging.getLogger(__name__)
 
 class Pyre(object):
 
-    def __init__(self, ctx=zmq.Context()):
+    def __init__(self, ctx=None, name=None):
+        """
+        Constructor, creates a new Zyre node. Note that until you start the
+        node it is silent and invisible to other nodes on the network.
+        The node name is provided to other nodes during discovery. If you
+        specify NULL, Zyre generates a randomized node name from the UUID.
+        """
+        if ctx == None:
+            ctx = zmq.Context()
         self._ctx = ctx
         self._uuid = None
-        self._name = None
+        self._name = name
         self.verbose = False
         self.inbox, self._outbox = zhelper.zcreate_pipe(self._ctx)
 
         # Start node engine and wait for it to be ready
         self.actor = ZActor(self._ctx, PyreNode, self._outbox)
-        # Send name, if any, to node ending 
+        # Send name, if any, to node backend 
         if (self._name):
             self.actor.send_unicode("SET NAME", zmq.SNDMORE)
             self.actor.send_unicode(self._name)
@@ -37,8 +45,16 @@ class Pyre(object):
         # to make sure our node thread is stopped
         #self.actor.destroy()
 
-    # Return our node UUID, after successful initialization
+    def __bool__(self):
+        "Determine whether the object is valid by converting to boolean" # Python 3
+        return True  #TODO
+
+    def __nonzero__(self):
+        "Determine whether the object is valid by converting to boolean" # Python 2
+        return True  #TODO
+
     def uuid(self):
+        """Return our node UUID string, after successful initialization"""
         if not self._uuid:
             self.actor.send_unicode("UUID")
             self._uuid = uuid.UUID(bytes=self.actor.recv())
@@ -46,6 +62,7 @@ class Pyre(object):
 
     # Return our node name, after successful initialization
     def name(self):
+        """Return our node name, after successful initialization"""
         if not self._name:
             self.actor.send_unicode("NAME")
             self._name = self.actor.recv().decode('utf-8')
@@ -53,31 +70,51 @@ class Pyre(object):
 
     # Not in Zyre api
     def set_name(self, name):
+        logger.warning("DEPRECATED: set name in constructor, this method will be removed!")
         self.actor.send_unicode("SET NAME", zmq.SNDMORE)
         self.actor.send_unicode(name)
 
-    # Set node header value
     def set_header(self, key, value):
+        """Set node header; these are provided to other nodes during discovery
+        and come in each ENTER message."""
         self.actor.send_unicode("SET HEADER", flags=zmq.SNDMORE)
         self.actor.send_unicode(key, flags=zmq.SNDMORE)
         self.actor.send_unicode(value)
 
     def set_verbose(self):
+        """Set verbose mode; this tells the node to log all traffic as well as 
+        all major events."""
         self.actor.send_unicode("SET VERBOSE")
 
     def set_port(self, port_nbt):
+        """Set UDP beacon discovery port; defaults to 5670, this call overrides 
+        that so you can create independent clusters on the same network, for 
+        e.g. development vs. production. Has no effect after zyre_start()."""
         self.actor.send_unicode("SET PORT", zmq.SNDMORE)
         self.actor.send(port_nbr)
 
     def set_interval(self, interval):
+        """Set UDP beacon discovery interval, in milliseconds. Default is instant
+        beacon exploration followed by pinging every 1,000 msecs."""
         self.actor.send_unicode("SET INTERVAL", zmq.SNDMORE)
         self.actor.send_unicode(interval)
 
     def set_interface(self, value):
-        logging.debug("set_interface not implemented")
+        """Set network interface for UDP beacons. If you do not set this, CZMQ will
+        choose an interface for you. On boxes with several interfaces you should
+        specify which one you want to use, or strange things can happen."""
+        logging.debug("set_interface not implemented") #TODO
 
     # TODO: check args from zyre
     def set_endpoint(self, format, *args):
+        """By default, Zyre binds to an ephemeral TCP port and broadcasts the local
+        host name using UDP beaconing. When you call this method, Zyre will use
+        gossip discovery instead of UDP beaconing. You MUST set-up the gossip
+        service separately using zyre_gossip_bind() and _connect(). Note that the
+        endpoint MUST be valid for both bind and connect operations. You can use
+        inproc://, ipc://, or tcp:// transports (for tcp://, use an IP address
+        that is meaningful to remote as well as local nodes). Returns 0 if
+        the bind was successful, else -1."""
         self.actor.send_unicode("SET ENDPOINT", zmq.SNDMORE)
         self.actor.send_unicode(format)
 
@@ -86,11 +123,17 @@ class Pyre(object):
     #def gossip_connect(self, format, *args):
 
     def start(self):
+        """Start node, after setting header values. When you start a node it
+        begins discovery and connection. Returns 0 if OK, -1 if it wasn't
+        possible to start the node."""
         self.actor.send_unicode("START")
         # the backend will signal back
         self.actor.resolve().wait()
 
     def stop(self):
+        """Stop node; this signals to other peers that this node will go away.
+        This is polite; however you can also just destroy the node without
+        stopping it."""
         self.actor.send_unicode("STOP", flags=zmq.DONTWAIT)
         # the backend will signal back
         self.actor.resolve().wait()
@@ -98,20 +141,26 @@ class Pyre(object):
 
     # Receive next message from node
     def recv(self):
+        """Receive next message from network; the message may be a control
+        message (ENTER, EXIT, JOIN, LEAVE) or data (WHISPER, SHOUT).
+        """
         return self.inbox.recv_multipart()
 
-    # Join a group
     def join(self, group):
+        """Join a named group; after joining a group you can send messages to
+        the group and all Zyre nodes in that group will receive them."""
         self.actor.send_unicode("JOIN", flags=zmq.SNDMORE)
         self.actor.send_unicode(group)
 
-    # Leave a group
     def leave(self, group):
+        """Leave a group"""
         self.actor.send_unicode("LEAVE", flags=zmq.SNDMORE)
         self.actor.send_unicode(group)
 
     # Send message to single peer; peer ID is first frame in message
     def whisper(self, peer, msg_p):
+        """Send message to single peer, specified as a UUID string
+        Destroys message after sending"""
         self.actor.send_unicode("WHISPER", flags=zmq.SNDMORE)
         self.actor.send(peer.bytes, flags=zmq.SNDMORE)
         if isinstance(msg_p, list):
@@ -119,8 +168,9 @@ class Pyre(object):
         else:
             self.actor.send(msg_p)
 
-    # Send message to a group of peers
     def shout(self, group, msg_p):
+        """Send message to a named group
+        Destroys message after sending"""
         self.actor.send_unicode("SHOUT", flags=zmq.SNDMORE)
         self.actor.send_unicode(group, flags=zmq.SNDMORE)
         if isinstance(msg_p, list):
@@ -128,22 +178,21 @@ class Pyre(object):
         else:
             self.actor.send(msg_p)
 
-    # Send message to single peer; peer ID is first frame in message
     # TODO: checks args from zyre
     def whispers(self, peer, format, *args):
+        """Send formatted string to a single peer specified as UUID string"""
         self.actor.send_unicode("WHISPER", flags=zmq.SNDMORE)
         self.actor.send(peer.bytes, flags=zmq.SNDMORE)
         self.actor.send_unicode(format)
 
     def shouts(self, group, format, *args):
+        """Send formatted string to a named group"""
         self.actor.send_unicode("SHOUT", flags=zmq.SNDMORE)
         self.actor.send_unicode(group, flags=zmq.SNDMORE)
         self.actor.send_unicode(format)
 
-    #  --------------------------------------------------------------------------
-    #  Return list of current peers. The caller owns this list and should
-    #  destroy it when finished with it.
     def peers(self):
+        """Return list of current peer ids."""
         self.actor.send_unicode("PEERS")
         peers = self.actor.recv_pyobj()
         return peers
@@ -159,46 +208,43 @@ class Pyre(object):
         name = self.actor.recv_unicode()
         return name
 
-    # --------------------------------------------------------------------------
-    # Return the endpoint of a connected peer. Caller owns the
-    # string.
     def peer_address(self, peer):
+        """Return the endpoint of a connected peer."""
         self.actor.send_unicode("PEER ENDPOINT", zmq.SNDMORE)
         self.actor.send(peer.bytes)
         adr = self.actor.recv_unicode()
         return adr
 
-    #  --------------------------------------------------------------------------
-    #  Return the value of a header of a conected peer. 
-    #  Returns null if peer or key doesn't exist.
     def peer_header_value(self, peer, name):
+        """Return the value of a header of a conected peer. 
+        Returns null if peer or key doesn't exist."""
         self.actor.send_unicode("PEER HEADER", zmq.SNDMORE)
         self.actor.send(peer.bytes, zmq.SNDMORE)
         self.actor.send_unicode(name)
         value = self.actor.recv_unicode()
         return value
 
-    #  --------------------------------------------------------------------------
-    #  Return zlist of currently joined groups.
     def own_groups(self):
+        """Return list of currently joined groups."""
         self.actor.send_unicode("OWN GROUPS");
         groups = self.actor.recv_pyobj()
         return groups
 
-    #  --------------------------------------------------------------------------
-    #  Return zlist of groups known through connected peers. 
     def peer_groups(self):
+        """Return list of groups known through connected peers."""
         self.actor.send_unicode("PEER GROUPS")
         groups = self.actor.recv_pyobj()
         return groups
 
     # Return node socket, for direct polling of socket
     def socket(self):
+        """Return socket for talking to the Zyre node, for polling"""
         return self.inbox
 
-    def version(self):
+    @staticmethod
+    def version():
         logger.warning("version() not implemented yet")
-
+        #return (major, minor, patch)
 
 def chat_task(ctx, pipe):
     n = Pyre(ctx)

--- a/pyre/pyre.py
+++ b/pyre/pyre.py
@@ -18,14 +18,19 @@ logger = logging.getLogger(__name__)
 
 class Pyre(object):
 
-    def __init__(self, ctx=None, name=None):
-        """
-        Constructor, creates a new Zyre node. Note that until you start the
+    def __init__(self, name=None, **kwargs):
+        """Constructor, creates a new Zyre node. Note that until you start the
         node it is silent and invisible to other nodes on the network.
         The node name is provided to other nodes during discovery. If you
         specify NULL, Zyre generates a randomized node name from the UUID.
+
+        Args:
+            name (str): The name of the node
+
+        Kwargs:
+            ctx: PyZMQ Context, if not specified a new context will be created
         """
-        if ctx == None:
+        if kwargs.get('ctx') == None:
             ctx = zmq.Context()
         self._ctx = ctx
         self._uuid = None

--- a/tests/test_pyre.py
+++ b/tests/test_pyre.py
@@ -32,32 +32,32 @@ class PyreTest(unittest.TestCase):
     # end tearDown
 
     def test_get_name(self):
-        self.assertEqual("node1", self.node1.get_name())
-        self.assertEqual("node2", self.node2.get_name())
+        self.assertEqual("node1", self.node1.name())
+        self.assertEqual("node2", self.node2.name())
     # end test_get_name
 
     def test_get_peers(self):
-        id1 = self.node1.get_uuid()
-        peers = self.node2.get_peers()
+        id1 = self.node1.uuid()
+        peers = self.node2.peers()
 
         self.assertIsInstance(peers, list)
         self.assertIn(id1, peers)
     # end test_get_peers
 
     def test_get_peer_address(self):
-        id1 = self.node1.get_uuid()
-        id2 = self.node2.get_uuid()
+        id1 = self.node1.uuid()
+        id2 = self.node2.uuid()
 
-        self.assertIsInstance(self.node1.get_peer_address(id2), unicode)
-        self.assertIsInstance(self.node2.get_peer_address(id1), unicode)
+        self.assertIsInstance(self.node1.peer_address(id2), unicode)
+        self.assertIsInstance(self.node2.peer_address(id1), unicode)
     # end test_get_peer_address
 
-    def test_get_peer_header_value(self):
-        id1 = self.node1.get_uuid()
-        id2 = self.node2.get_uuid()
+    def test_peer_header_value(self):
+        id1 = self.node1.uuid()
+        id2 = self.node2.uuid()
 
-        self.assertEqual("1", self.node1.get_peer_header_value(id2, "X-TEST"))
-        self.assertEqual("1", self.node2.get_peer_header_value(id1, "X-TEST"))
+        self.assertEqual("1", self.node1.peer_header_value(id2, "X-TEST"))
+        self.assertEqual("1", self.node2.peer_header_value(id1, "X-TEST"))
     # end test_get_peer_header_value
 
     def test_get_own_groups(self):
@@ -66,8 +66,8 @@ class PyreTest(unittest.TestCase):
         # pyre works asynchronous so give some time to let changes disperse
         time.sleep(0.5)
 
-        self.assertIn("TEST", self.node1.get_own_groups())
-        self.assertIn("TEST", self.node2.get_own_groups())
+        self.assertIn("TEST", self.node1.own_groups())
+        self.assertIn("TEST", self.node2.own_groups())
     # end test_get_own_groups
 
     def test_join_leave_msg(self):
@@ -95,8 +95,8 @@ class PyreTest(unittest.TestCase):
         # pyre works asynchronous so give some time to let changes disperse
         time.sleep(0.5)
 
-        self.assertIn("TEST", self.node1.get_peer_groups())
-        self.assertIn("TEST", self.node2.get_peer_groups())
+        self.assertIn("TEST", self.node1.peer_groups())
+        self.assertIn("TEST", self.node2.peer_groups())
     # end test_get_peer_groups
 
     def test_whispers(self):
@@ -104,10 +104,10 @@ class PyreTest(unittest.TestCase):
         self.assertEqual(msg[0], b'ENTER')
         msg = self.node2.recv()
         self.assertEqual(msg[0], b'ENTER')
-        self.node1.whispers(self.node2.get_uuid(), "Hi")
+        self.node1.whispers(self.node2.uuid(), "Hi")
         msg = self.node2.recv()
         self.assertEqual(b"WHISPER", msg[0])
-        self.assertEqual(self.node1.get_uuid().bytes, msg[1])
+        self.assertEqual(self.node1.uuid().bytes, msg[1])
         self.assertEqual(b"node1", msg[2])
         self.assertEqual(b"Hi", msg[3])
 
@@ -125,7 +125,7 @@ class PyreTest(unittest.TestCase):
         self.node1.shouts("TEST", "Hi")
         msg = self.node2.recv()
         self.assertEqual(b"SHOUT", msg[0])
-        self.assertEqual(self.node1.get_uuid().bytes, msg[1])
+        self.assertEqual(self.node1.uuid().bytes, msg[1])
         self.assertEqual(b"node1", msg[2])
         self.assertEqual(b"TEST", msg[3])
         self.assertEqual(b"Hi", msg[4])

--- a/tests/test_pyre.py
+++ b/tests/test_pyre.py
@@ -14,12 +14,10 @@ class PyreTest(unittest.TestCase):
     
     def setUp(self, *args, **kwargs):
         ctx = zmq.Context()
-        self.node1 = pyre.Pyre(ctx)
+        self.node1 = pyre.Pyre("node1", ctx=ctx)
         self.node1.set_header("X-TEST", "1")
-        self.node1.set_name("node1")
-        self.node2 = pyre.Pyre(ctx)
+        self.node2 = pyre.Pyre("node2", ctx=ctx)
         self.node2.set_header("X-TEST", "1")
-        self.node2.set_name("node2")
         self.node1.start()
         self.node2.start()
         # give time for nodes to exchange


### PR DESCRIPTION
Since we have official python bindings for Zyre I'm aiming for Pyre to be a drop in replacement of Zyre in case no Zyre libs are available on a host. Therefore the API needs to be exactly the same. This PR does that.

As Pyre is still in development I've not provided compatibility. Please step forward if you object. 