### PR TITLE
Skip over link-locals when selecting an interface.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ nosetests.xml
 _build
 _static
 _templates
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,6 @@ nosetests.xml
 _build
 _static
 _templates
+
+# Pycharm
 .idea/

--- a/pyre/zbeacon.py
+++ b/pyre/zbeacon.py
@@ -169,6 +169,10 @@ class ZBeacon(object):
                     logger.debug("Interface {0} is a loopback device.".format(name))
                     continue
 
+                if interface.is_link_local:
+                    logger.debug("Interface {0} is a link-local device.".format(name))
+                    continue
+
                 self.address = interface.ip
                 self.network_address = interface.network.network_address
                 self.broadcast_address = interface.network.broadcast_address

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 setup(
         name='pyre',
-        version='0.2',
+        version='0.3',
         description='Python ZRE implementation',
         author='Arnaud Loonstra',
         author_email='arnaud@sphaero.org',


### PR DESCRIPTION
During interface selection, this will prevent zbeacon from choosing a link-local device.  It is useful on a development system with interfaces that are enabled but disconnected, for example virtual or secondary NICs.