### PR TITLE
Problem: Pyre crashes

### DIFF
--- a/pyre/pyre_peer.py
+++ b/pyre/pyre_peer.py
@@ -85,15 +85,15 @@ class PyrePeer(object):
                 msg.send(self.mailbox)
             except zmq.AGAIN as e:
                 self.disconnect()
-                logger.debug("{0} Error while sending {1} to peer={2} sequence={3}".format(self.origin, 
-                                                                            msg.get_command(), 
-                                                                            self.name, 
+                logger.debug("{0} Error while sending {1} to peer={2} sequence={3}".format(self.origin,
+                                                                            msg.get_command(),
+                                                                            self.name,
                                                                             msg.get_sequence()))
                 return -1
 
-            logger.debug("{0} send {1} to peer={2} sequence={3}".format(self.origin, 
-                msg.get_command(), 
-                self.name, 
+            logger.debug("{0} send {1} to peer={2} sequence={3}".format(self.origin,
+                msg.get_command(),
+                self.name,
                 msg.get_sequence()))
 
         else:
@@ -184,11 +184,11 @@ class PyrePeer(object):
     def messages_lost(self, msg):
         # The sequence number set by the peer, and our own calculated
         # sequence number should be the same.
-        logger.debug("(%s) recv %s from peer=%s sequence=%d",
+        logger.debug("(%s) recv %s from peer=%s sequence=%d"%(
             self.origin,
             msg.get_command(),
             self.name,
-            msg.get_sequence());
+            msg.get_sequence()) )
         if msg.get_command == "HELLO":
             self.want_sequence = 1
         else:

--- a/pyre/zre_msg.py
+++ b/pyre/zre_msg.py
@@ -70,10 +70,13 @@ class ZreMsg(object):
         frames = input_socket.recv_multipart()
         if input_socket.socket_type == zmq.ROUTER:
             self.address = frames.pop(0)
+            print self.address[1:]
             # we drop the first byte: TODO ref!
-            self.address = uuid.UUID(bytes=self.address[1:])
-            if not self.address:
+            try:
+                self.address = uuid.UUID(bytes=self.address[1:])
+            except ValueError:
                 logger.debug("Peer identity frame empty or malformed")
+                return None
 
         # Read and parse command in frame
         self.struct_data = frames.pop(0)
@@ -268,24 +271,24 @@ class ZreMsg(object):
 
     def get_name(self):
         return self.name
-    
+
     def set_name(self, name):
         self.name = name
-    
+
     # Get/set the sequence field
     def get_sequence(self):
         return self.sequence
 
     def set_sequence(self, sequence):
         self.sequence = sequence
-    
+
     # Get/set the endpoint field
     def get_endpoint(self):
         return self.endpoint
-    
+
     def set_endpoint(self, endpoint):
         self.endpoint = endpoint
-        
+
     # Get/set the ipaddress field
     def get_ipaddress(self):
         return self.ipaddress

--- a/pyre/zre_msg.py
+++ b/pyre/zre_msg.py
@@ -70,7 +70,6 @@ class ZreMsg(object):
         frames = input_socket.recv_multipart()
         if input_socket.socket_type == zmq.ROUTER:
             self.address = frames.pop(0)
-            print self.address[1:]
             # we drop the first byte: TODO ref!
             try:
                 self.address = uuid.UUID(bytes=self.address[1:])


### PR DESCRIPTION
Problem details:
1) `PyrePeer` crashes on malformed `logger.debug` call
2) `ZreMsg` raises `ValueError` if address is malformed

Solution:
1) Fix debug call format
2) try/catch on `UUID` creation, return `None` on failure

Also: Removes some trailing whitespaces.