### PR TITLE
Problem: Pyre misses access to own endpoint information

### DIFF
--- a/pyre/pyre.py
+++ b/pyre/pyre.py
@@ -204,6 +204,11 @@ class Pyre(object):
         peers = self.actor.recv_pyobj()
         return peers
 
+    def endpoint(self):
+        self.actor.send_unicode("ENDPOINT")
+        endpoint = self.actor.recv_unicode()
+        return endpoint
+
     # --------------------------------------------------------------------------
     # Return the name of a connected peer. Caller owns the
     # string.

--- a/pyre/pyre_event.py
+++ b/pyre/pyre_event.py
@@ -59,3 +59,6 @@ class PyreEvent(object):
             TYPE: uuid.UUID
         """
         return uuid.UUID(bytes=self.peer_uuid_bytes)
+
+    def __str__(self):
+        return '<%s %s from %s>'%(__name__, self.type, self.peer_uuid.hex)

--- a/pyre/pyre_node.py
+++ b/pyre/pyre_node.py
@@ -235,6 +235,8 @@ class PyreNode(object):
                 logger.debug("Node is leaving group {0}".format(grpname))
         elif command == "PEERS":
             self._pipe.send_pyobj(list(self.peers.keys()))
+        elif command == "ENDPOINT":
+            self._pipe.send_unicode(self.endpoint)
         elif command == "PEER NAME":
             id = uuid.UUID(bytes=request.pop(0))
             peer = self.peers.get(id)


### PR DESCRIPTION
Solution: Implement "ENDPOINT" command that returns pyre_node.endpoint