### PR TITLE
Problem: Typo in pyre_peer and bad error handling in pyre_event

### DIFF
--- a/pyre/pyre_event.py
+++ b/pyre/pyre_event.py
@@ -14,11 +14,7 @@ class PyreEvent(object):
             node (Pyre): Pyre node
         """
         super(PyreEvent, self).__init__()
-        try:
-            incoming = node.recv()
-        except zmq.ZMQError:
-            # recv failed.
-            return None
+        incoming = node.recv()
 
         self.type = incoming.pop(0).decode('utf-8')
         self.peer_uuid_bytes = incoming.pop(0)

--- a/pyre/pyre_peer.py
+++ b/pyre/pyre_peer.py
@@ -83,7 +83,7 @@ class PyrePeer(object):
 
             try:
                 msg.send(self.mailbox)
-            except zmq.AGAIN as e:
+            except zmq.Again as e:
                 self.disconnect()
                 logger.debug("{0} Error while sending {1} to peer={2} sequence={3}".format(self.origin,
                                                                             msg.get_command(),

--- a/pyre/zbeacon.py
+++ b/pyre/zbeacon.py
@@ -263,7 +263,7 @@ class ZBeacon(object):
         try:
             self.udpsock.sendto(self.transmit, (str(self.broadcast_address),
                                                 self.port_nbr))
-        except OSError:
+        except (OSError, socket.error):
             logger.debug("Network seems gone, exiting zbeacon")
             self.terminated = True
 
@@ -291,9 +291,6 @@ class ZBeacon(object):
             if self.transmit and time.time() >= self.ping_at:
                 self.send_beacon()
                 self.ping_at = time.time() + self.interval
-
-            if self.terminated:
-                break
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Solutions:

1.  Use `zmq.Again` which is a wrapper for `zmq.EAGAIN`
2. Remove `try/except` in `PyreEvent.__init__`. Let user handle the error explicitly.