### PR TITLE
Problem: Missing PyreEvent iterators

### DIFF
--- a/pyre/pyre.py
+++ b/pyre/pyre.py
@@ -210,10 +210,16 @@ class Pyre(object):
         endpoint = self.actor.recv_unicode()
         return endpoint
 
-    def events(self):
+    def recent_events(self):
+        """Iterator that yields recent `PyreEvent`s"""
         while self.socket().get(zmq.EVENTS) & zmq.POLLIN:
             yield PyreEvent(self)
         raise StopIteration()
+
+    def events(self):
+        """Iterator that yields `PyreEvent`s indefinitely"""
+        while True:
+            yield PyreEvent(self)
 
     # --------------------------------------------------------------------------
     # Return the name of a connected peer. Caller owns the

--- a/pyre/pyre.py
+++ b/pyre/pyre.py
@@ -12,6 +12,7 @@ from . import zhelper
 from .zactor import ZActor
 from .zsocket import ZSocket
 from .pyre_node import PyreNode
+from .pyre_event import PyreEvent
 
 logger = logging.getLogger(__name__)
 
@@ -208,6 +209,11 @@ class Pyre(object):
         self.actor.send_unicode("ENDPOINT")
         endpoint = self.actor.recv_unicode()
         return endpoint
+
+    def events(self):
+        while self.socket().get(zmq.EVENTS) & zmq.POLLIN:
+            yield PyreEvent(self)
+        raise StopIteration()
 
     # --------------------------------------------------------------------------
     # Return the name of a connected peer. Caller owns the

--- a/tests/test_pyre.py
+++ b/tests/test_pyre.py
@@ -11,7 +11,7 @@ if sys.version.startswith('3'):
 
 
 class PyreTest(unittest.TestCase):
-    
+
     def setUp(self, *args, **kwargs):
         ctx = zmq.Context()
         self.node1 = pyre.Pyre("node1", ctx=ctx)


### PR DESCRIPTION
Solution: Build two `PyreEvent` iterators:
1. `Pyre.recent_events()`: Yields events as long as there are POLLIN events in the inbox
2. `Pyre.events()`: Yields events indefinitely.