### PR TITLE
Remove Python 3.2 and 3.3 from testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,11 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
 
-matrix:
-  include:
-  - python: 3.2
-    env: PYVER="3.2"
-
 install:
-  - if [[ $PYVER == "3.2" ]]; then pip install -U "virtualenv<14.0.0" "pip<8.0.0" "setuptools<30.0.0"; fi
   - pip install nose
   - pip install .
 


### PR DESCRIPTION
__Problems:__
* Python 3.2 is already removed but there are still tests for its presence.
* Python 3.3 goes EOL later this month
    * https://docs.python.org/devguide/index.html#branchstatus

__Solution:__
* Remove all mention of Python 3.2 and 3.3 from `.travis.yml`