### PR TITLE
Fix crash when peer status exceeds 127

### DIFF
--- a/pyre/pyre_peer.py
+++ b/pyre/pyre_peer.py
@@ -153,7 +153,7 @@ class PyrePeer(object):
 
     # Set peer status
     def set_status(self, status):
-        self.status = status
+        self.status = status & 0xFF
     # end set_status
 
     # Return peer ready state

--- a/pyre/zre_msg.py
+++ b/pyre/zre_msg.py
@@ -343,8 +343,8 @@ class ZreMsg(object):
         return s[0].decode('UTF-8')
 
     def _get_number1(self):
-        num = struct.unpack_from('>b', self.struct_data, offset=self._needle)
-        self._needle += struct.calcsize('>b')
+        num = struct.unpack_from('>B', self.struct_data, offset=self._needle)
+        self._needle += struct.calcsize('>B')
         return num[0]
 
     def _get_number2(self):
@@ -374,7 +374,7 @@ class ZreMsg(object):
         self.struct_data += d
 
     def _put_number1(self, nr):
-        d = struct.pack('>b', nr)
+        d = struct.pack('>B', nr)
         self.struct_data += d
 
     def _put_number2(self, nr):


### PR DESCRIPTION
The internal status of `PyrePeer` isn't restricted to the bounds of `number1`, leading to a `struct.error` during otherwise normal operation.

Additionally, `ZreMsg` reads/writes `number1` as a signed byte instead of an unsigned byte as is done in `Zyre`.