### PR TITLE
Fix stopping Pyre after network disconnect 

### DIFF
--- a/pyre/pyre_node.py
+++ b/pyre/pyre_node.py
@@ -109,13 +109,14 @@ class PyreNode(object):
     def stop(self):
         logger.debug("Pyre node: stopping beacon")
         if self.beacon:
-            stop_transmit = struct.pack('cccb16sH', b'Z',b'R',b'E',
-                                   BEACON_VERSION, self.identity.bytes,
-                                   socket.htons(0))
-            self.beacon.send_unicode("PUBLISH", zmq.SNDMORE)
-            self.beacon.send(stop_transmit)
-            # Give time for beacon to go out
-            time.sleep(0.001)
+            if self.beacon.is_running:
+                stop_transmit = struct.pack('cccb16sH', b'Z',b'R',b'E',
+                                       BEACON_VERSION, self.identity.bytes,
+                                       socket.htons(0))
+                self.beacon.send_unicode("PUBLISH", zmq.SNDMORE)
+                self.beacon.send(stop_transmit)
+                # Give time for beacon to go out
+                time.sleep(0.001)
             self.poller.unregister(self.beacon_socket)
             self.beacon.destroy()
             self.beacon = None

--- a/pyre/zactor.py
+++ b/pyre/zactor.py
@@ -70,10 +70,13 @@ class ZActor(object):
         if self.tag == 0xDeadBeef:
             logger.warning("Zactor: already destroyed")
             return
-        self.pipe.set(zmq.SNDTIMEO, 0)
-        self.pipe.send_unicode("$TERM")
-        # misschien self.pipe.wait()????
-        self.pipe.wait()
+        try:
+            self.pipe.set(zmq.SNDTIMEO, 0)
+            self.pipe.send_unicode("$TERM")
+            # misschien self.pipe.wait()????
+            self.pipe.wait()
+        except zmq.error.Again:
+            pass
         self.pipe.close()
         self.tag = 0xDeadBeef;
 

--- a/pyre/zactor.py
+++ b/pyre/zactor.py
@@ -43,6 +43,7 @@ class ZActor(object):
         self.shim_handler = actor
         self.shim_args = (self.ctx, self.shim_pipe)+args
         self.shim_kwargs = kwargs
+        self.is_running = False
         self.thread = threading.Thread(target=self.run)
         # we manage threads exiting ourselves!
         self.thread.daemon = False
@@ -54,10 +55,12 @@ class ZActor(object):
         self.pipe.wait()
 
     def run(self):
+        self.is_running = True
         self.shim_handler(*self.shim_args, **self.shim_kwargs)
         self.shim_pipe.set(zmq.SNDTIMEO, 0)
         self.shim_pipe.signal()
         self.shim_pipe.close()
+        self.is_running = False
 
     def destroy(self):
         # Signal the actor to end and wait for the thread exit code


### PR DESCRIPTION
This PR addresses #135 

---

##### Alternative solutions considered:

- Implementing beacon reconnect on connection drops. However, it is not clear what the exact behavior should be and how it fits into the overall system. Maybe this PR could fuel further discussions on this topic.
