### PR TITLE
Fix compsleep kills zbeacon

### DIFF
--- a/pyre/zbeacon.py
+++ b/pyre/zbeacon.py
@@ -263,7 +263,15 @@ class ZBeacon(object):
         try:
             self.udpsock.sendto(self.transmit, (str(self.broadcast_address),
                                                 self.port_nbr))
-        except (OSError, socket.error):
+            
+        except OSError as e:
+        # network down, just wait, it could come back up again.
+            if e.errno == 50: pass
+            # all other cases, we'll terminate
+            else:
+                logger.debug("Network seems gone, exiting zbeacon")
+                self.terminated = True
+        except socket.error:
             logger.debug("Network seems gone, exiting zbeacon")
             self.terminated = True
 

--- a/pyre/zbeacon.py
+++ b/pyre/zbeacon.py
@@ -266,7 +266,10 @@ class ZBeacon(object):
             
         except OSError as e:
         # network down, just wait, it could come back up again.
-            if e.errno == 50: pass
+        # socket call errors 50 and 51 relate to the network being
+        # down or unreachable, the recommended action to take is to 
+        # try again so we don't terminate in these cases.
+            if e.errno in [50, 51]: pass
             # all other cases, we'll terminate
             else:
                 logger.debug("Network seems gone, exiting zbeacon")

--- a/pyre/zbeacon.py
+++ b/pyre/zbeacon.py
@@ -38,6 +38,8 @@ logger = logging.getLogger(__name__)
 INTERVAL_DFLT = 1.0
 BEACON_MAX = 255      # Max size of beacon data
 MULTICAST_GRP = '225.25.25.25'
+ENETDOWN = 50   #socket error, network is down
+ENETUNREACH = 51 #socket error, network unreachable
 
 
 class ZBeacon(object):
@@ -265,15 +267,18 @@ class ZBeacon(object):
                                                 self.port_nbr))
             
         except OSError as e:
-        # network down, just wait, it could come back up again.
-        # socket call errors 50 and 51 relate to the network being
-        # down or unreachable, the recommended action to take is to 
-        # try again so we don't terminate in these cases.
-            if e.errno in [50, 51]: pass
+            
+            # network down, just wait, it could come back up again.
+            # socket call errors 50 and 51 relate to the network being
+            # down or unreachable, the recommended action to take is to 
+            # try again so we don't terminate in these cases.
+            if e.errno in [ENETDOWN, ENETUNREACH]: pass
+            
             # all other cases, we'll terminate
             else:
                 logger.debug("Network seems gone, exiting zbeacon")
                 self.terminated = True
+                
         except socket.error:
             logger.debug("Network seems gone, exiting zbeacon")
             self.terminated = True


### PR DESCRIPTION
Hey guys, This PR is my first ever, so pls forgive me if I violate any conventions :). I started trying out pyre a week ago, but ran into issues when computers entered sleep. I am working on MacOS systems, specifically 10.14.5. I am using the latest pyre master, as of writing this PR - a34ce3e7d0aeb1f2203d79b46a747f8f36b48430 

**PROBLEM**
To reproduce the issue, I simply start a node on two computers both attached to an access point:
`import pyre`
`n = pyre.Pyre()`
`n.join("CHAT")`
`n.start()`

I can see that both computers are sending their zbeacons to the broadcast address which is fine. I then let either one of them go to sleep. Once I wake the sleepy computer up, it no longer sends any beacons to the broadcast address. 

I ran the same setup in debug and noticed that in zbeacon.py, the self.terminated boolean was being set for all socket call errors. IBM suggests that not all are fatal warranting termination. You can see that information here -> [Sockets return codes (ERRNOs)](https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.4.0/com.ibm.zos.v2r4.hala001/syserret.htm). Specifically I was getting Errno 50 or 51 for the computer going to sleep, which correspond to ENETDOWN and ENETUNREACH, neither of which are fatal.

I modified the try/except block in `ZBeacon.send_beacon` to leave self.terminate as False if either of the above errors was the cause of the except block being triggered. This solves the problem I had for the beacon failing after computer's entering sleep. I can see beacons resuming sending after waking the computers where they didn't before. I can run the tests in the pyre package which also succeed.

Kind Regards

James


