### PR TITLE
 Remove previous peer on duplicated endpoint

### DIFF
--- a/pyre/pyre_node.py
+++ b/pyre/pyre_node.py
@@ -289,6 +289,7 @@ class PyreNode(object):
 
     def purge_peer(self, peer, endpoint):
         if (peer.get_endpoint() == endpoint):
+            self.remove_peer(peer)
             peer.disconnect()
             logger.debug("Purge peer: {0}{1}".format(peer,endpoint))
 


### PR DESCRIPTION
Problem: If a peer with an unknown uuid connects, and there was known peer with the same endpoint, the previous peer is purged silently.

By removing the peer explicitly, the Pyre user receives an EXIT event for the purged peer and which allows the user to properly cleanup any resources bound to the purged peer.