### PR TITLE
Deploy source distribution to PyPI using Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,43 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on: [push, pull_request]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+
+  build_sdist:
+      name: Build source distribution
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - uses: actions/setup-python@v1
+          with:
+            python-version: 3.7
+        - name: Build source package
+          run: |
+            pip install build
+            python -m build --sdist .
+        - name: Upload source package
+          uses: actions/upload-artifact@v2
+          with:
+            name: distribution
+            path: dist/
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [build_sdist]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: distribution
+          path: dist/
+      - name: Publish to PyPI
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def find_version(*file_paths):
 
 
 setup(
-        name='pyre',
+        name='zeromq-pyre',
         version=find_version('pyre', '__init__.py'),
         description='Python ZRE implementation',
         author='Arnaud Loonstra',


### PR DESCRIPTION
## Summary

This PR is an attempt to solve #14

This PR introduces a small Github Action to build a source distribution (`sdist`, using the official `build` module) and uses the official Github Action for deploying it to PyPI.

## Deployment trigger
The Action builds the `sdist` on all pushes and pull requests. (Ideally, this `sdist` would be used for running the tests.) If the `push` event is associated with a `git tag` and the `sdist` build was successful, it will attempt to deploy the `sdist` to PyPI. 

### Maintainer action required
In order for the deployment to work, the maintainers need to set up a repository secret named `PYPI_TOKEN`. You can read more about PyPI API tokens [here](https://pypi.org/help/#apitoken).

After merging, a new tag needs to be created and pushed to initiate the deployment.

## Deployment name
As discussed in #14, the `pyre` PyPI project is already taken by http://pyre.orthologue.com/. I feel like `zeromq-pyre` (proposed by @brettviren in https://github.com/zeromq/pyre/issues/14#issuecomment-571166373) is the most sensible alternative. I adjusted the project name to be `zeromq-pyre` accordingly.

Since the module name does not change, running `pip install zeromq-pyre` will overwrite previous pyre installations. **Note** It will not replace the pip entry for the previous pyre installation. It is therefore recommended to
- run `pip uninstall pyre` before `pip install zeromq-pyre`, or
- manually delete the `.../lib/python3.8/site-packages/pyre-0.3.2-py3.8.egg-info` folder

## Future work

In order to further simplify the deployment process, one could setup a [`bump2version`](https://github.com/c4urself/bump2version) config. One could go even one step further, and build an additional Github Action that can be triggered manually by the maintainer to run `bump2version` on the master and therefore initiating a new deployment.

Later, one could migrate the Travis tests to be a requirement for the deployment, as well. Currently, the tests seem to fail on Travis though.