### PR TITLE
implements set_interface

### DIFF
--- a/pyre/pyre.py
+++ b/pyre/pyre.py
@@ -117,7 +117,8 @@ class Pyre(object):
         """Set network interface for UDP beacons. If you do not set this, CZMQ will
         choose an interface for you. On boxes with several interfaces you should
         specify which one you want to use, or strange things can happen."""
-        logging.debug("set_interface not implemented") #TODO
+        self.actor.send_unicode("SET INTERFACE", zmq.SNDMORE)
+        self.actor.send_unicode(value)
 
     # TODO: check args from zyre
     def set_endpoint(self, format, *args):

--- a/pyre/pyre_node.py
+++ b/pyre/pyre_node.py
@@ -27,6 +27,7 @@ class PyreNode(object):
         self.outbox = outbox                        # Outbox back to application
         self._terminated = False                    # API shut us down
         self._verbose = False                       # Log all traffic (logging module?)
+        self.interface_name = None                  # Network interface
         self.beacon_port = ZRE_DISCOVERY_PORT       # Beacon port number
         self.interval = 0                           # Beacon interval 0=default
         self.beacon = None                          # Beacon actor
@@ -67,6 +68,9 @@ class PyreNode(object):
             if self._verbose:
                 self.beacon.send_unicode("VERBOSE")
 
+            if self.interface_name:
+                self.beacon.send_unicode("SET INTERFACE", zmq.SNDMORE)
+                self.beacon.send_unicode(self.interface_name)
 
             # Our hostname is provided by zbeacon
             self.beacon.send_unicode("CONFIGURE", zmq.SNDMORE)
@@ -160,6 +164,8 @@ class PyreNode(object):
             self.beacon_port = int(request.pop(0))
         elif command == "SET INTERVAL":
             self.interval = int(request.pop(0))
+        elif command == "SET INTERFACE":
+            self.interface_name = request.pop(0).decode()
         #elif command == "SET ENDPOINT":
             # TODO: gossip start and endpoint setting
         # TODO: GOSSIP BIND, GOSSIP CONNECT

--- a/tests/test_zbeacon.py
+++ b/tests/test_zbeacon.py
@@ -10,7 +10,6 @@ from pyre.zbeacon import ZBeacon
 class ZBeaconTest(unittest.TestCase):    
     def setUp(self, *args, **kwargs):
         ctx = zmq.Context()
-        ctx = zmq.Context()
         # two beacon frames
         self.transmit1 = struct.pack('cccb16sH', b'Z', b'R', b'E',
                            1, uuid.uuid4().bytes,


### PR DESCRIPTION
if selected interface is a single digit, then it is used as an array index in the network interface list
otherwise the selected interface is attempted
otherwise the default behaviour of looping through the network interface list, selecting the first eligible.

this continues the closed pull request here: https://github.com/zeromq/pyre/pull/164

